### PR TITLE
feat: filter out debit statement records

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,11 @@ cat dbo-statement.csv | DBO2TAXER_ACCOUNT_NAME="ФОП" dbo2taxer
 
 The list of environment variables and default values.
 
-| Variable                | Default value    | Meaning                            |
-| ----------------------- | ---------------- | ---------------------------------- |
-| DBO2TAXER_ACCOUNT_NAME  | ""               | Name of account in the income list |
-| DBO2TAXER_OPERATION     | "Дохід"          | Type of operation                  |
-| DBO2TAXER_INCOME_TYPE   | "Основний дохід" | The type of income for taxation    |
-| DBO2TAXER_CURRENCY_CODE | "UAH"            | Income currency                    |
+| Variable               | Default value    | Meaning                            |
+| ---------------------- | ---------------- | ---------------------------------- |
+| DBO2TAXER_ACCOUNT_NAME | ""               | Name of account in the income list |
+| DBO2TAXER_OPERATION    | "Дохід"          | Type of operation                  |
+| DBO2TAXER_INCOME_TYPE  | "Основний дохід" | The type of income for taxation    |
 
 ### Specify input and output files
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,6 @@ pub struct TaxerConfig {
     pub income_type: String,
     #[serde(default)]
     pub account_name: String,
-    #[serde(default)]
-    pub currency_code: String,
 }
 
 impl Default for TaxerConfig {
@@ -19,7 +17,6 @@ impl Default for TaxerConfig {
             operation: "Дохід".to_string(),
             income_type: "Основний дохід".to_string(),
             account_name: "".to_string(),
-            currency_code: "UAH".to_string(),
         }
     }
 }
@@ -30,7 +27,6 @@ impl TaxerConfig {
         let config = config::Config::builder()
             .set_default("operation", default_config.operation)?
             .set_default("income_type", default_config.income_type)?
-            .set_default("currency_code", default_config.currency_code)?
             .add_source(config::Environment::with_prefix("DBO2TAXER"))
             .build()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,9 @@ fn convert_records(
 ) -> anyhow::Result<Vec<TaxerRecord>> {
     let mut taxer_operations = vec![];
     for dbo in statement.into_inner() {
-        taxer_operations.push(convert_record(dbo, config)?);
+        if dbo.credit.is_some() {
+            taxer_operations.push(convert_record(dbo, config)?);
+        }
     }
     Ok(taxer_operations)
 }
@@ -52,13 +54,13 @@ fn convert_records(
 fn convert_record(record: DboRecord, config: &TaxerConfig) -> anyhow::Result<TaxerRecord> {
     TaxerRecord::builder()
         .tax_code_raw(record.party_tax_id)?
-        .amount_raw(record.coverage)?
+        .amount_raw(record.credit.unwrap())?
         .date(record.operation_date)
         .comment(record.payment_purpose)
         .operation(config.operation.clone())
         .income_type(config.income_type.clone())
         .account_name(config.account_name.clone())
-        .currency_code(config.currency_code.clone())
+        .currency_code(record.currency.clone())
         .build()
         .map_err(|err| anyhow::anyhow!(err))
 }


### PR DESCRIPTION
Fix #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the environment variables table, removing the `DBO2TAXER_CURRENCY_CODE` entry and refining table formatting.

* **Bug Fixes**
  * Enhanced record conversion to process only records with a credit value and use the input record's currency code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->